### PR TITLE
removed mongodbUrl from logs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,12 +23,12 @@
     options = Hoek.applyToDefaults(defaults, options);
     Hoek.assert(options.mongodbUrl, 'Missing required mongodbUrl property in options.');
     startDb = function() {
-      server.log(['plugin', 'info', 'hapi-mongoose-db-connector'], "Mongoose connecting to " + options.mongodbUrl);
+      server.log(['plugin', 'info', 'hapi-mongoose-db-connector'], "Mongoose connecting to MongoDB");
       return mongoose.connect(options.mongodbUrl, options.mongoOptions, function(err) {
         if (err) {
           return server.log(['plugin', 'error', 'fatal', 'hapi-mongoose-db-connector'], "Mongoose connection failure");
         } else {
-          return server.log(['plugin', 'info', 'hapi-mongoose-db-connector'], "Mongoose connected to " + options.mongodbUrl);
+          return server.log(['plugin', 'info', 'hapi-mongoose-db-connector'], "Mongoose connected to MongoDB");
         }
       });
     };


### PR DESCRIPTION
Having mongo db url with its user/pass in the logs is a big security risk
