### PR TITLE
Set mongoose to use native promise library

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@
   Hoek = require("hoek");
 
   mongoose = require('mongoose');
+  mongoose.Promise = global.Promise;
 
   Mixed = mongoose.Schema.Types.Mixed;
 


### PR DESCRIPTION
Mongoose’s default promise library has been deprecated causing a
warning message stating that fact. This added line removes the warning
and sets the promise library to use the native promise library.